### PR TITLE
Scatterplot stuff

### DIFF
--- a/components/rarity-gradient.js
+++ b/components/rarity-gradient.js
@@ -1,10 +1,7 @@
 import { Text, Box, useColorModeValue } from '@chakra-ui/react';
 
-function RarityGradient({ val }) {
-  let color, gradient, min, max;
-  let heat = useColorModeValue('.400', '.300');
-  let borderHeat = useColorModeValue('.300', '.400');
-
+export function getMinMaxGradient(val) {
+  let min, max
   switch (val) {
     case 'epic':
       max = 'orange.300';
@@ -36,6 +33,15 @@ function RarityGradient({ val }) {
       min = 'gray.500';
       break;
   }
+  return {min, max}
+}
+
+function RarityGradient({ val }) {
+  // let color, gradient, min, max;
+  let heat = useColorModeValue('.400', '.300');
+  let borderHeat = useColorModeValue('.300', '.400');
+
+  let {min, max} = getMinMaxGradient(val)
   return <Box bgGradient={`linear(to-r, ${min}, ${max})`} height="5px"></Box>;
 }
 export default RarityGradient;

--- a/components/scatterplot.js
+++ b/components/scatterplot.js
@@ -1,0 +1,175 @@
+import {
+  Box,
+  Center,
+  Flex,
+  HStack,
+  Radio,
+  RadioGroup,
+  Stack,
+  Text,
+  Tooltip,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import React from 'react';
+import { VictoryAxis, VictoryChart } from 'victory';
+import Rarity from './rarity';
+import { getMinMaxGradient } from './rarity-gradient';
+
+export default function ScatterPlot() {
+  const colors = ['blue', 'red', 'green', 'orange', 'purple', 'teal', 'yellow'];
+  const axisLabelColor = useColorModeValue('black', 'white');
+  const filterBg = useColorModeValue('gray.50', 'gray.900');
+  const inputBg = useColorModeValue('white', 'gray.700');
+
+  const scatterData = [
+    // colors should match up with rarity.js
+    // x and y fields are the coordinate values displayed in the tooltip
+    { rarity: 'legendary', color: 'pink.300', left: 0.8, top: 0.3, x: 3.4, y: 1.55, size: 17 },
+    { rarity: 'epic', color: 'yellow.400', left: 0.6, top: 0.7, x: 1.55, y: -2.5, size: 21 },
+    { rarity: 'rare', color: 'orange.400', left: 0.5, top: 0.2, x: 0.6, y: 2.4, size: 26 },
+    { rarity: 'common', color: 'green.300', left: 0.3, top: 0.3, x: -1.7, y: 1.5, size: 16 },
+    { rarity: 'uncommon', color: 'gray.500', left: 0.8, top: 0.8, x: 3.2, y: -3.25, size: 10 },
+    { rarity: 'anomaly', color: 'blue.300', left: 0.5, top: 0.5, x: 0.2, y: -0.2, size: 8 },
+  ];
+
+  return (
+    <Box p={[5, 5, 10]}>
+      <Center>
+        <RadioGroup defaultValue="1">
+          <Stack spacing={4} direction="row">
+            <Radio value="0">All Games</Radio>
+            <Radio value="1" isChecked>
+              Star Atlas
+            </Radio>
+            <Radio value="2" isDisabled>
+              DefiLand
+            </Radio>
+            <Radio value="3" isDisabled>
+              Aurory
+            </Radio>
+          </Stack>
+        </RadioGroup>
+      </Center>
+
+      <HStack mt={5} mb={-5} justify="center">
+        {scatterData.map((x, idx) => (
+          <Rarity val={x.rarity} key={idx}/>
+        ))}
+      </HStack>
+
+      {/* Chart */}
+      <Center>
+        <Flex>
+          <Tooltip
+            placement="left"
+            hasArrow
+            label="Simple Moving Average (SMA) Z-Score indicates the direction of price movement"
+          >
+            <Center width={100}>Price Direction (SMA) Z-Score ⓘ</Center>
+          </Tooltip>
+
+          <Box>
+            {/* <Center> */}
+            <Box height={[300, 400, 500, 600]} width={[300, 400, 500, 600]} position="relative">
+              <VictoryChart height={500} width={500}>
+                <VictoryAxis
+                  domain={[-4, 4]}
+                  crossAxis
+                  tickValues={[-4, -3, -2, -1, 0, 1, 2, 3, 4]}
+                  style={{
+                    tickLabels: { fill: axisLabelColor, fontSize: 12 },
+                    axis: { stroke: 'gray' },
+                    grid: { stroke: 'gray', strokeWidth: 0.5 },
+                  }}
+                />
+                <VictoryAxis
+                  domain={[-4, 4]}
+                  crossAxis
+                  dependentAxis
+                  tickValues={[-4, -3, -2, -1, 1, 2, 3, 4]}
+                  style={{
+                    tickLabels: { fill: axisLabelColor, fontSize: 12 },
+                    axis: { stroke: 'gray' },
+                    grid: { stroke: 'gray', strokeWidth: 0.5 },
+                  }}
+                />
+              </VictoryChart>
+              {/* <Image src={gridImage} width="100%" height="100%" zIndex={1} position="relative" /> */}
+              {scatterData.map(({ ...props }, idx) => {
+                return <Bubble {...props} key={idx} />;
+              })}
+            </Box>
+            {/* </Center> */}
+
+            <Tooltip
+              placement="bottom"
+              hasArrow
+              label="Average Directional Index (ADX) Z-Score indicates the strength or weakness of a trend"
+            >
+              <Center>Trend Strength (ADX Z-Score) ⓘ</Center>
+            </Tooltip>
+          </Box>
+        </Flex>
+      </Center>
+    </Box>
+  );
+}
+
+function Bubble(props) {
+  const { rarity, color, left, top, x, y, size, idx } = props;
+  // const bg = useColorModeValue(color + '.400', color + '.200');
+  const bg = color;
+  return (
+    <Tooltip bg="none" key={idx} label={<BubbleInfo {...props} />}>
+      <Box
+        bg={bg}
+        cursor="pointer"
+        border="2px"
+        boxSize={size * 3 + 'px'}
+        rounded="full"
+        opacity={0.85}
+        _hover={{ opacity: 1 }}
+        position="absolute"
+        left={left * 100 + '%'}
+        top={top * 100 + '%'}
+        zIndex={10}
+      ></Box>
+    </Tooltip>
+  );
+}
+
+function BubbleInfo(props) {
+  const { rarity, color, left, top, x, y, size, idx } = props;
+  const { min, max } = getMinMaxGradient(rarity);
+  return (
+    <Box
+      border="1px"
+      height="170px"
+      width="170px"
+      rounded="md"
+      bgGradient={`linear(to-r, ${min}, ${max})`}
+    >
+      <Center mb={1}>
+        <Rarity val={rarity} />
+      </Center>
+      <Text mx={1} mb={-1} size="xs" color="gray.700">
+        Trend Strength (ADX)
+      </Text>
+      <Text mx={1} fontSize="lg" color="white" borderBottomWidth={1}>
+        {x}
+      </Text>
+      <Text mx={1} mb={-1} size="xs" color="gray.700">
+        Price Direction (SMA)
+      </Text>
+      <Text mx={1} fontSize="lg" color="white" borderBottomWidth={1}>
+        {y}
+      </Text>
+      <Text mx={1} mb={-1} size="xs" color="gray.700">
+        Daily Volume
+      </Text>
+      <Text mx={1} fontSize="lg" color="white">
+        {Math.round(Math.random() * 10000)}
+      </Text>
+    </Box>
+  );
+}

--- a/components/scatterplot.js
+++ b/components/scatterplot.js
@@ -22,9 +22,9 @@ export default function ScatterPlot() {
   const inputBg = useColorModeValue('white', 'gray.700');
 
   const scatterData = [
-    // colors should match up with rarity.js
-    // x and y fields are the coordinate values displayed in the tooltip
-    { rarity: 'legendary', color: 'pink.300', left: 0.8, top: 0.3, x: 3.4, y: 1.55, size: 17 },
+    // 'x' and 'y' fields are the coordinate values displayed in the tooltip. If you decide to change
+    // the 'left' and 'top' values, then you'll need to change the x and y values as well so the tooltip is believable
+    { rarity: 'legendary', color: 'pink.300', left: 0.8, top: 0.3, x: 3.4, y: 1.55, size: 20 },
     { rarity: 'epic', color: 'yellow.400', left: 0.6, top: 0.7, x: 1.55, y: -2.5, size: 21 },
     { rarity: 'rare', color: 'orange.400', left: 0.5, top: 0.2, x: 0.6, y: 2.4, size: 26 },
     { rarity: 'common', color: 'green.300', left: 0.3, top: 0.3, x: -1.7, y: 1.5, size: 16 },
@@ -53,7 +53,7 @@ export default function ScatterPlot() {
 
       <HStack mt={5} mb={-5} justify="center">
         {scatterData.map((x, idx) => (
-          <Rarity val={x.rarity} key={idx}/>
+          <Rarity val={x.rarity} key={idx} />
         ))}
       </HStack>
 
@@ -133,7 +133,9 @@ function Bubble(props) {
         left={left * 100 + '%'}
         top={top * 100 + '%'}
         zIndex={10}
-      ></Box>
+      >
+        <Center height="100%">{x > 0 && y > 0 ? '🔥' : ''}</Center>
+      </Box>
     </Tooltip>
   );
 }

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -11,6 +11,7 @@ import {
   Line,
 } from 'victory';
 import Layout from '../components/layout';
+import ScatterPlot from '../components/scatterplot';
 import {
   Button,
   Center,
@@ -237,13 +238,18 @@ const Home: NextPage = () => {
                       30k
                     </Box>
 
-                    <Box alignSelf="flex-end">Terra</Box>
+                    <Box alignSelf="flex-end">Solanart</Box>
                   </Box>
                 </Box>
               </Box>
             </Box>
 
             <SimpleGrid columns={[1, 1, 1]} spacing={[5, 5, 8]}>
+              <Box borderBottomWidth={1}>
+                <Heading ml={5} mb={-5} size="md">Price vs Trend Analysis</Heading>
+                <ScatterPlot />
+              </Box>
+
               <Box borderBottomWidth={1} pl={5}>
                 <Heading size="md">Portfolio Value (USDC)</Heading>
                 <Heading fontSize="lg" color="gray.500" fontWeight="500" mt={2} mb={[-5, -8, -12]}>


### PR DESCRIPTION
-moved scatterplot to dashboard
-uses victorychart axes and grid instead of placeholder images
-added enough info to be intuitive. can always add more

TODO:
-I think we should pretty up the axes and somehow make the y-axis text vertically rotated
-Clicking on bubble should link to Star Atlas "All Items" page with the filter set to the clicked item category (I'll figure this out)

<img width="795" alt="image" src="https://user-images.githubusercontent.com/5816365/136725442-8ab4a2ae-d82f-41fd-b396-ccd7265dacff.png">
