### PR TITLE
Switch to SSR for caching fix

### DIFF
--- a/pages/game/[slug].js
+++ b/pages/game/[slug].js
@@ -228,53 +228,19 @@ const Page = ({ game = {}, markets = [] }) => {
 
 export default Page;
 
-export async function getStaticPaths() {
-  const data = [
-    {
-      name: 'Star Atlas',
-      description: 'Lorem',
-      slug: 'star-atlas',
-      _id: 'foobar',
-      image: '/star-atlas.jpg',
-      symbol: 'SA',
-    },
-  ];
-
-  const paths = data.map((el, idx) => {
-    return {
-      params: {
-        slug: el['slug'],
-        data: el,
-        // handle: el["_id"],
-      },
-    };
-  });
-
-  return {
-    paths,
-    fallback: true,
-  };
-}
-
-export async function getStaticProps({ params, locale, locales, preview }) {
-  const gamesData = [
-    {
-      name: 'Star Atlas',
-      description: 'Lorem',
-      slug: 'star-atlas',
-      _id: 'foobar',
-      image: '/star-atlas.jpg',
-      symbol: 'SA',
-    },
-  ];
-
+export async function getServerSideProps(context) {
   const markets = await getAllStarAtlasMarkets();
 
   return {
     props: {
-      game: gamesData.filter((el) => {
-        return el['slug'] === params.slug;
-      })[0],
+      game: {
+        name: 'Star Atlas',
+        description: 'Lorem',
+        slug: 'star-atlas',
+        _id: 'foobar',
+        image: '/star-atlas.jpg',
+        symbol: 'SA',
+      },
       markets: markets,
     },
   };


### PR DESCRIPTION
Background: when hosted on vercel, the statically generated html for this page was overriding the rarity gradients of initially filtered items, which leads me to believe it was being cached by the browser.

fix: switch from static props to server side props so this shit doesn't happen in the first place